### PR TITLE
Replace HashSet with LinkedHashSet

### DIFF
--- a/src/main/java/byteceps/activities/Workout.java
+++ b/src/main/java/byteceps/activities/Workout.java
@@ -2,7 +2,7 @@
 package byteceps.activities;
 
 import java.util.ArrayList;
-import java.util.HashSet;
+import java.util.LinkedHashSet;
 import java.util.ListIterator;
 
 /**
@@ -39,8 +39,8 @@ public class Workout extends Activity {
      *
      * @return A set of exercises.
      */
-    public HashSet<Exercise> getExerciseSet() {
-        return new HashSet<>(exerciseList);
+    public LinkedHashSet<Exercise> getExerciseSet() {
+        return new LinkedHashSet<>(exerciseList);
     }
 
     /**

--- a/src/main/java/byteceps/activities/WorkoutLog.java
+++ b/src/main/java/byteceps/activities/WorkoutLog.java
@@ -1,15 +1,15 @@
 package byteceps.activities;
 
-import java.util.HashSet;
+import java.util.LinkedHashSet;
 
 
 public class WorkoutLog extends Activity {
     protected final String workoutName;
-    HashSet<ExerciseLog> exerciseLogs;
+    LinkedHashSet<ExerciseLog> exerciseLogs;
     public WorkoutLog(String workoutDate, String workoutName) {
         super(workoutDate);
         this.workoutName = workoutName;
-        this.exerciseLogs = new HashSet<>();
+        this.exerciseLogs = new LinkedHashSet<>();
     }
 
     public void addExerciseLog(ExerciseLog exerciseLog) {
@@ -25,7 +25,7 @@ public class WorkoutLog extends Activity {
         return activityName;
     }
 
-    public HashSet<ExerciseLog> getExerciseLogs() {
+    public LinkedHashSet<ExerciseLog> getExerciseLogs() {
         return exerciseLogs;
     }
 }

--- a/src/main/java/byteceps/processing/ActivityManager.java
+++ b/src/main/java/byteceps/processing/ActivityManager.java
@@ -6,7 +6,7 @@ import byteceps.errors.Exceptions;
 import byteceps.ui.strings.ManagerStrings;
 
 import java.util.ArrayList;
-import java.util.HashSet;
+import java.util.LinkedHashSet;
 import java.util.Iterator;
 
 /**
@@ -14,11 +14,11 @@ import java.util.Iterator;
  */
 public abstract class ActivityManager {
     protected final String activityType;
-    protected final HashSet<Activity> activitySet;
+    protected final LinkedHashSet<Activity> activitySet;
 
     public ActivityManager() {
         this.activityType = getActivityType(false);
-        this.activitySet = new HashSet<>();
+        this.activitySet = new LinkedHashSet<>();
     }
 
     /**

--- a/src/main/java/byteceps/processing/WeeklyProgramManager.java
+++ b/src/main/java/byteceps/processing/WeeklyProgramManager.java
@@ -15,7 +15,7 @@ import java.time.DayOfWeek;
 import java.time.LocalDate;
 import java.time.format.DateTimeFormatter;
 import java.time.format.DateTimeParseException;
-import java.util.HashSet;
+import java.util.LinkedHashSet;
 
 public class WeeklyProgramManager extends ActivityManager {
     private final ExerciseManager exerciseManager;
@@ -255,9 +255,9 @@ public class WeeklyProgramManager extends ActivityManager {
                 );
             }
             String workoutName = workoutDay.getAssignedWorkout().getActivityName();
-            HashSet<Exercise> workoutHashSet = givenWorkout.getExerciseSet();
+            LinkedHashSet<Exercise> workoutLinkedHashSet = givenWorkout.getExerciseSet();
             workoutLogsManager.addWorkoutLog(workoutDate, workoutName);
-            return workoutLogsManager.getWorkoutLogString(workoutDate, workoutHashSet);
+            return workoutLogsManager.getWorkoutLogString(workoutDate, workoutLinkedHashSet);
 
         } catch (Exceptions.ActivityDoesNotExists e) {
             // catch so that it does not show error

--- a/src/main/java/byteceps/processing/WorkoutLogsManager.java
+++ b/src/main/java/byteceps/processing/WorkoutLogsManager.java
@@ -12,7 +12,7 @@ import org.json.JSONArray;
 import org.json.JSONObject;
 
 import java.util.ArrayList;
-import java.util.HashSet;
+import java.util.LinkedHashSet;
 
 public class WorkoutLogsManager extends ActivityManager {
     @Override
@@ -48,11 +48,11 @@ public class WorkoutLogsManager extends ActivityManager {
         }
     }
 
-    public String getWorkoutLogString(String date, HashSet<Exercise> workoutHashSet)
+    public String getWorkoutLogString(String date, LinkedHashSet<Exercise> workoutLinkedHashSet)
             throws Exceptions.ActivityDoesNotExists {
         WorkoutLog retrievedWorkout = (WorkoutLog) retrieve(date);
-        HashSet<ExerciseLog> exerciseLogs = retrievedWorkout.getExerciseLogs();
-        HashSet<Exercise> tempSet = new HashSet<>(workoutHashSet);
+        LinkedHashSet<ExerciseLog> exerciseLogs = retrievedWorkout.getExerciseLogs();
+        LinkedHashSet<Exercise> tempSet = new LinkedHashSet<>(workoutLinkedHashSet);
         StringBuilder result = new StringBuilder();
         result.append(String.format(
                 ManagerStrings.LOG_LIST, date));
@@ -94,7 +94,7 @@ public class WorkoutLogsManager extends ActivityManager {
             String workoutDate = currentWorkout.getWorkoutDate();
             String workoutName = currentWorkout.getWorkoutName();
 
-            HashSet<ExerciseLog> exercises = currentWorkout.getExerciseLogs();
+            LinkedHashSet<ExerciseLog> exercises = currentWorkout.getExerciseLogs();
             JSONObject workoutJson = getWorkoutJson(exercises, workoutName, workoutDate);
 
             workouts.put(workoutJson);
@@ -102,7 +102,7 @@ public class WorkoutLogsManager extends ActivityManager {
         return workouts;
     }
 
-    private static JSONObject getWorkoutJson(HashSet<ExerciseLog> exercises,
+    private static JSONObject getWorkoutJson(LinkedHashSet<ExerciseLog> exercises,
                                              String workoutName, String workoutDate) {
         JSONArray workoutExercises = new JSONArray();
         for (ExerciseLog currentExercise : exercises) {


### PR DESCRIPTION
Replace HashSet with LinkedHashSet across project; HashSet does not guarantee consistent ordering of elements based on insertion order whereas LinkedHashSet does

Fixes #69 