### PR TITLE
Log two of the same exercises on the same day

### DIFF
--- a/src/main/java/byteceps/activities/ExerciseLog.java
+++ b/src/main/java/byteceps/activities/ExerciseLog.java
@@ -24,4 +24,21 @@ public class ExerciseLog extends Activity {
     public int getWeight() {
         return weight;
     }
+
+    @Override
+    public boolean equals(Object obj) {
+        if (this == obj) {
+            return true;
+        }
+
+        if (obj == null) {
+            return false;
+        }
+
+        if (getClass() != obj.getClass()) {
+            return false;
+        }
+
+        return false;
+    }
 }


### PR DESCRIPTION
Add override Equals() method to ExerciseLog to allow duplicate log
Fixes #114 
![image](https://github.com/AY2324S2-CS2113-F14-3/tp/assets/68402849/c014e802-e825-49f4-a32b-eed9ff160e27)
![image](https://github.com/AY2324S2-CS2113-F14-3/tp/assets/68402849/26d9149c-1d8c-4483-8a89-077be62300fc)
